### PR TITLE
Fixed brand images causing layout shifts

### DIFF
--- a/components/components/Card.tsx
+++ b/components/components/Card.tsx
@@ -7,11 +7,11 @@ const Card = ({ title, image, slug, translate }: any) => {
   return (
     <div className="max-w-[550px] max-h-[550px] mb-10 bg-gradient-to-t from-stone-600 to-stone-200 rounded">
       <div className="ml-4 w-[150px] mt-1">
-        <Image 
+        <img
         src={image} 
         alt={title} 
-        width={1000} 
-        height={563} 
+        width="150"
+        height="79" 
         />
       </div>
       <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">

--- a/components/components/Card.tsx
+++ b/components/components/Card.tsx
@@ -11,8 +11,7 @@ const Card = ({ title, image, slug, translate }: any) => {
         src={image} 
         alt={title} 
         width={150}
-        height={79}
-        className="w-[150px] h-[79px]"
+        height={75}
         />
       </div>
       <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">

--- a/components/components/Card.tsx
+++ b/components/components/Card.tsx
@@ -7,11 +7,12 @@ const Card = ({ title, image, slug, translate }: any) => {
   return (
     <div className="max-w-[550px] max-h-[550px] mb-10 bg-gradient-to-t from-stone-600 to-stone-200 rounded">
       <div className="ml-4 w-[150px] mt-1">
-        <img
+        <Image
         src={image} 
         alt={title} 
-        width="150"
-        height="79" 
+        width={150}
+        height={79}
+        className="w-[150px] h-[79px]"
         />
       </div>
       <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">

--- a/components/katalozi/Card.tsx
+++ b/components/katalozi/Card.tsx
@@ -285,11 +285,11 @@ const Card = ({ translate }: any) => {
           >
             <div>
               <div className="ml-4 w-[150px]">
-                <Image
+                <img
                   src={catalog.img}
                   alt={catalog.title}
-                  width={1000}
-                  height={563}
+                  width="150"
+                  height="79"
                 />
               </div>
               <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">

--- a/components/katalozi/Card.tsx
+++ b/components/katalozi/Card.tsx
@@ -285,11 +285,12 @@ const Card = ({ translate }: any) => {
           >
             <div>
               <div className="ml-4 w-[150px]">
-                <img
+                <Image
                   src={catalog.img}
                   alt={catalog.title}
-                  width="150"
-                  height="79"
+                  width={150}
+                  height={79}
+                  className="w-[150px] h-[79px]"
                 />
               </div>
               <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">

--- a/components/katalozi/Card.tsx
+++ b/components/katalozi/Card.tsx
@@ -289,8 +289,7 @@ const Card = ({ translate }: any) => {
                   src={catalog.img}
                   alt={catalog.title}
                   width={150}
-                  height={79}
-                  className="w-[150px] h-[79px]"
+                  height={75}
                 />
               </div>
               <div className="text-start ml-4 mb-2 text-3xl  whitespace-nowrap overflow-hidden text-ellipsis">


### PR DESCRIPTION
I did a bit of research and it looks like the \<Image/> component for Next.js has this problem sometimes. Apparently to fix the component, you need to change something with CSS aspect ratio or use some other niche work around. However, using HTML's \<img/> tag fixes this issue and there isn't a noticeable performance difference. 

Let me know if you want to try a different approach.