### PR TITLE
Updated About Us to be consistent with other pages

### DIFF
--- a/pages/onama/index.tsx
+++ b/pages/onama/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Head from "next/head";
 import Mapa from "@/components/Mapa";
+import Hero from "@/components/Hero";
 
 const index = () => {
   const { t: translate } = useTranslation("home");
@@ -16,9 +17,12 @@ const index = () => {
         />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <h1 className="text-3xl sm:text-5xl font-medium text-center pb-12 pt-12">
-        {translate("O nama")}
-      </h1>
+
+      <Hero
+        translate={translate}
+        titleNaHomePage={translate("O nama")}
+        opisNaHomePage={translate("AboutUsDescription")}
+      />
       <div className="max-w-[1140px] mx-auto p-3 flex flex-col-reverse lg:flex-row mb-10 sm:mb-20">
         <div className="max-w-full lg:max-w-[570px] lg:mb-0">
           <Image

--- a/pages/onama/index.tsx
+++ b/pages/onama/index.tsx
@@ -23,7 +23,7 @@ const index = () => {
         titleNaHomePage={translate("O nama")}
         opisNaHomePage={translate("AboutUsDescription")}
       />
-      <div className="max-w-[1140px] mx-auto p-3 flex flex-col-reverse lg:flex-row mb-10 sm:mb-20">
+      <div className="max-w-[1140px] py-20 px-4 mx-auto flex flex-col-reverse lg:flex-row">
         <div className="max-w-full lg:max-w-[570px] lg:mb-0">
           <Image
             priority
@@ -34,7 +34,7 @@ const index = () => {
             height={1080}
           />
         </div>
-        <div className="max-w-full lg:max-w-[570px] lg:pl-10 mb-4">
+        <div className="max-w-full lg:max-w-[570px] lg:pl-10">
           <h2 className="sm:text-3xl text-2xl font-medium">
             {translate("Osnivanje")}
           </h2>
@@ -46,30 +46,31 @@ const index = () => {
           </p>
         </div>
       </div>
-
-      <div className="max-w-[1140px] mx-auto p-3 flex flex-col lg:flex-row mb-10 sm:mb-20">
-        <div className="max-w-full lg:max-w-[570px] lg:pr-10 mb-4">
-          <h2 className="sm:text-3xl text-2xl font-medium">
-            {translate("Veleprodaja i maloprodaja")}
-          </h2>
-          <span className="separator"></span>
-          <p>
-            {" "}
-            {translate("tekst 2 o nama")}
-            {/* {" "} */}
-          </p>
-        </div>
-        <div className="max-w-full lg:max-w-[570px]">
-          <Image
-            src="/altina1.png"
-            alt="Stridon altina maloprodaja"
-            className="rounded-md w-full"
-            width={1920}
-            height={1080}
-          />
+      <div className="w-full bg-stone-50 ">
+        <div className="max-w-[1140px] py-20 px-4 mx-auto flex flex-col lg:flex-row">
+          <div className="max-w-full lg:max-w-[570px] lg:pr-10">
+            <h2 className="sm:text-3xl text-2xl font-medium">
+              {translate("Veleprodaja i maloprodaja")}
+            </h2>
+            <span className="separator"></span>
+            <p>
+              {" "}
+              {translate("tekst 2 o nama")}
+              {/* {" "} */}
+            </p>
+          </div>
+          <div className="max-w-full lg:max-w-[570px]">
+            <Image
+              src="/altina1.png"
+              alt="Stridon altina maloprodaja"
+              className="rounded-md w-full"
+              width={1920}
+              height={1080}
+            />
+          </div>
         </div>
       </div>
-      <div className="max-w-[1140px] mx-auto p-3 flex flex-col-reverse lg:flex-row mb-10">
+      <div className="max-w-[1140px] py-20 px-4 mx-auto flex flex-col-reverse lg:flex-row">
         <div className="max-w-full lg:max-w-[570px] lg:mb-0">
           <Image
             priority
@@ -80,7 +81,7 @@ const index = () => {
             height={1080}
           />
         </div>
-        <div className="max-w-full lg:max-w-[570px] lg:pl-10 mb-4">
+        <div className="max-w-full lg:max-w-[570px] lg:pl-10">
           <h2 className="sm:text-3xl text-2xl font-medium">
             {translate("Internet prodavnica")}
           </h2>
@@ -92,13 +93,15 @@ const index = () => {
           </p>
         </div>
       </div>
-      <Mapa
-        translate={translate}
-        email={"office@stridon.rs"}
-        kontakt={"011/2886-509"}
-        adresa={"Vojislava Ilića 141g"}
-        map_src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d90567.5103257972!2d20.365943012636272!3d44.81678309583739!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x475a7163a682044d%3A0x2a07a073e49f36ae!2sStridon%20group!5e0!3m2!1sen!2snl!4v1682522248790!5m2!1sen!2snl"
-      />
+      <div className="bg-stone-50">
+        <Mapa
+          translate={translate}
+          email={"office@stridon.rs"}
+          kontakt={"011/2886-509"}
+          adresa={"Vojislava Ilića 141g"}
+          map_src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d90567.5103257972!2d20.365943012636272!3d44.81678309583739!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x475a7163a682044d%3A0x2a07a073e49f36ae!2sStridon%20group!5e0!3m2!1sen!2snl!4v1682522248790!5m2!1sen!2snl"
+        />
+      </div>
       <Mapa
         translate={translate}
         email={"office@stridon.rs"}

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -482,6 +482,7 @@
   "Podaci za Identifikaciju · ": "Identification Data · ",
   "Politika Privatnosti": "Privacy Policy",
 
+  "AboutUsDescription": "",
   "tekst 1 o nama": "Our company Stridon Group doo - Tool Store was founded in 2009 in Belgrade with headquarters in Borivoja Stevanovića street, and a retail outlet at Vojislava Ilića 141g. After a few years, we managed to open another sales facility on the other side of Belgrade - Ugrinovačka 212 (Altina), to provide stable and affordable tool supply to customers in all parts of Belgrade.",
   "tekst 2 o nama": "We are a company engaged in wholesale and retail trade, as well as internet sales, which makes us unique in the world of tools in Serbia. We sell brands of hand and power tools, accessories, protective equipment, gardening tools, vacuum cleaners, and much more! We are authorized importers and distributors of a vast number of global and domestic brands such as DeWalt, Bosch, Stanley, REMS, Wiha, Knipex, GTV, MAX, Högert, Wera, Rubi, Senco, Black+Decker, MTX, Sparta, SG Tools, Karcher, Wolfcraft.",
   "tekst 3 o nama": "On our online store, you can find over 60,000 items, and we are the largest online tool store in Serbia. Whether you have a construction company, you are a tool trader, or just a DIY enthusiast, we are the right tool supplier for you! Our company has been the best distributor of Bosch tools for 9 consecutive years, and this year, we are also the best distributor of DeWalt, Stanley, and Black+Decker tools in Serbia!",

--- a/public/locales/sr/home.json
+++ b/public/locales/sr/home.json
@@ -482,6 +482,7 @@
   "Podaci za Identifikaciju · ": "Podaci za Identifikaciju · ",
   "Politika Privatnosti": "Politika Privatnosti",
 
+  "AboutUsDescription": "",
   "tekst 1 o nama": "Naša firma Stridon Group doo - Prodavnica alata je osnovana 2009. godine u Beogradu sa sedištem u ulici Borivoja Stevanovića, a maloprodajnim objektom na adresi Vojislava Ilića 141g. Nakon par godina uspeli smo da otvorimo još jedan prodajni objekat na drugoj strani Beograda - Ugrinovačka 212 (Altina), kako bismo omogućili kupcima u svim delovima Beograda stabilno i povoljno snabdevanje alatom.",
   "tekst 2 o nama": "Mi smo firma koja se bavi trgovinom na veliko i malo, kao i internet prodajom što nas čini jedinstvenim u svetu alata u Srbiji. Prodajemo brendove ručnog i električnog alata, pribora, zaštitne opreme, baštenskog alata, usisivača i još toliko toga! Ovlašćeni smo uvoznici i distributeri ogromnog broja svetskih i domaćih brendova kao što su: DeWalt, Bosch, Stanley, REMS, Wiha, Knipex, GTV, MAX, Högert, Wera, Rubi, Senco, Black+Decker, MTX, Sparta, SG Tools, Karcher, Wolfcraft.",
   "tekst 3 o nama": "Na našoj internet prodavnici možete pronaći preko 60.000 artikala i najveća smo online prodavnica alata u Srbiji. Bilo da imate građevinsku firmu, ili da ste trgovac alatima, ili samo DIY entuzijasta, mi smo pravi dobavljač alata za Vas! Naša firma je najbolji distributer Bosch alata 9 godina u nizu, a od ove godine smo i najbolji distributer DeWalt, Stanley i Black+Decker alata u Srbiji!",


### PR DESCRIPTION
I updated the header of the 'About Us' page to use the \<Hero/> component. There was no description for the About Us page, so I just added an empty key-value pair into the Serbian and English translation JSON files in order to prevent a type error with the `opisNaHomePage` property. If you want me to change the description to something specific or delete the About Us description, let me know.
I did not edit rest of the About Us page because it looks consistent with the rest of the website to me. Let me know if you wanted the rest of this page to look a certain way or if you want me to make a component for the body text.

Resolves #14 