### PR TITLE
Updated image alt attribute to be more descriptive

### DIFF
--- a/components/Brendovi.tsx
+++ b/components/Brendovi.tsx
@@ -68,63 +68,63 @@ const Brendovi: React.FC<BrendoviProps> = ({ translate }) => {
           swipeable={false}
         >
           <Link href={"/brendovi/dewalt"}>
-            <BrendoviImg brendoviImg={dewalt} title="DeWalt" />
+            <BrendoviImg brendoviImg={dewalt} title="DeWalt Logo" />
           </Link>
 
           <Link href={"/brendovi/stanley"}>
-            <BrendoviImg brendoviImg={stanley} title="Stanley" />
+            <BrendoviImg brendoviImg={stanley} title="Stanley Logo" />
           </Link>
 
           <Link href={"/brendovi/bosch"}>
-            <BrendoviImg brendoviImg={bosch} title="Bosch" />
+            <BrendoviImg brendoviImg={bosch} title="Bosch Logo" />
           </Link>
 
           <Link href={"/brendovi/knipex"}>
-            <BrendoviImg brendoviImg={knipex} title="Knipex" />
+            <BrendoviImg brendoviImg={knipex} title="Knipex Logo" />
           </Link>
 
           <Link href={"/brendovi/wiha"}>
-            <BrendoviImg brendoviImg={wiha} title="Wiha" />
+            <BrendoviImg brendoviImg={wiha} title="Wiha Logo" />
           </Link>
 
           <Link href={"/brendovi/hogert"}>
-            <BrendoviImg brendoviImg={hoegert} title="Hogert" />
+            <BrendoviImg brendoviImg={hoegert} title="Hogert Logo" />
           </Link>
 
           <Link href={"/brendovi/gtv"}>
-            <BrendoviImg brendoviImg={gtv} title="GTV" />
+            <BrendoviImg brendoviImg={gtv} title="GTV Logo" />
           </Link>
 
           <Link href={"/brendovi/rems"}>
-            <BrendoviImg brendoviImg={rems} title="Rems" />
+            <BrendoviImg brendoviImg={rems} title="Rems Logo" />
           </Link>
 
           <Link href={"/brendovi/max"}>
-            <BrendoviImg brendoviImg={max} title="Max" />
+            <BrendoviImg brendoviImg={max} title="Max Logo" />
           </Link>
 
           <Link href={"/brendovi/wera"}>
-            <BrendoviImg brendoviImg={wera} title="Wera" />
+            <BrendoviImg brendoviImg={wera} title="Wera Logo" />
           </Link>
 
           <Link href={"/brendovi/mtx"}>
-            <BrendoviImg brendoviImg={mtx} title="MTX" />
+            <BrendoviImg brendoviImg={mtx} title="MTX Logo" />
           </Link>
 
           <Link href={"/brendovi/sgtools"}>
-            <BrendoviImg brendoviImg={sgtools} title="SGTools" />
+            <BrendoviImg brendoviImg={sgtools} title="SGTools Logo" />
           </Link>
 
           <Link href={"/brendovi/blackdecker"}>
-            <BrendoviImg brendoviImg={blackdecker} title="Black+Decker" />
+            <BrendoviImg brendoviImg={blackdecker} title="Black+Decker Logo" />
           </Link>
 
           <Link href={"/brendovi/rubi"}>
-            <BrendoviImg brendoviImg={rubi} title="Rubi" />
+            <BrendoviImg brendoviImg={rubi} title="Rubi Logo" />
           </Link>
 
           <Link href={"/brendovi/senco"}>
-            <BrendoviImg brendoviImg={senco} title="Senco" />
+            <BrendoviImg brendoviImg={senco} title="Senco Logo" />
           </Link>
         </Carousel>
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -61,7 +61,7 @@ const Hero: React.FC<HeroProps> = ({
         onClose={handleOnClose}
         visible={visible}
       />
-      <img className="absolute right-0 w-[600px] opacity-10 sm:opacity-30 rotate-45 sm:rotate-0" src="/drill-electric.svg" alt="Test" />
+      <img className="absolute right-0 w-[600px] opacity-10 sm:opacity-30 rotate-45 sm:rotate-0" src="/drill-electric.svg" alt="Drill as header's background" />
     </div>
   );
 };

--- a/components/servis/Brendovi.tsx
+++ b/components/servis/Brendovi.tsx
@@ -60,21 +60,21 @@ const Brendovi: React.FC<BrendoviProps> = ({ title, textBelowTitle }) => {
           swipeable={false}
         >
           <Link href={"/brendovi/dewalt"}>
-            <BrendoviImg brendoviImg={dewaltLogo} title="DeWalt"/>
+            <BrendoviImg brendoviImg={dewaltLogo} title="DeWalt Logo"/>
           </Link>
           <Link href={"/brendovi/bosch"}>
-            <BrendoviImg brendoviImg={boschLogo} title="Bosch"/>
+            <BrendoviImg brendoviImg={boschLogo} title="Bosch Logo"/>
           </Link>
         
-          <BrendoviImg brendoviImg={makitaLogo} title="Makita"/>
-          <BrendoviImg brendoviImg={metaboLogo} title="Metabo"/>
-          <BrendoviImg brendoviImg={festoolLogo} title="Festool"/>
+          <BrendoviImg brendoviImg={makitaLogo} title="Makita Logo"/>
+          <BrendoviImg brendoviImg={metaboLogo} title="Metabo Logo"/>
+          <BrendoviImg brendoviImg={festoolLogo} title="Festool Logo"/>
 
           <Link href={"/brendovi/rubi"}>
-            <BrendoviImg brendoviImg={rubiLogo} title="Rubi"/>
+            <BrendoviImg brendoviImg={rubiLogo} title="Rubi Logo"/>
           </Link>
           <Link href={"/brendovi/senco"}>
-            <BrendoviImg brendoviImg={sencoLogo} title="Senco"/>
+            <BrendoviImg brendoviImg={sencoLogo} title="Senco Logo"/>
           </Link>
         </Carousel>
       </div>

--- a/pages/brendovi/black-and-decker/index.tsx
+++ b/pages/brendovi/black-and-decker/index.tsx
@@ -20,7 +20,7 @@ const index = () => {
         translate={translate}
       />
       <TextoviISlike
-        title={"Black+Decker"}
+        title={"Black+Decker Logo"}
         naslovPasusa1={translate("naslov pasusa 1 black+decker")}
         naslovPasusa2={translate("naslov pasusa 2 black+decker")}
         naslovPasusa3={translate("naslov pasusa 3 black+decker")}

--- a/pages/brendovi/bosch/index.tsx
+++ b/pages/brendovi/bosch/index.tsx
@@ -51,7 +51,7 @@ const index = () => {
         catalogueValues={boschKatalogVrednosti}
       />
       <TextoviISlike
-        title={"Bosch"}
+        title={"Bosch Logo"}
         naslovPasusa1={translate("naslov pasusa 1 bosch")}
         naslovPasusa2={translate("naslov pasusa 2 bosch")}
         naslovPasusa3={translate("naslov pasusa 3 bosch")}

--- a/pages/brendovi/dewalt/index.tsx
+++ b/pages/brendovi/dewalt/index.tsx
@@ -33,7 +33,7 @@ const index = () => {
         catalogueValues={dewaltKatalogVrednosti}
       />
       <TextoviISlike
-        title={translate("Dewalt")}
+        title={"DeWalt Logo"}
         naslovPasusa1={translate("naslov pasusa 1 dewalt")}
         textPasusa1={translate("text pasusa 1 dewalt")}
         slika1={dewalt}

--- a/pages/brendovi/gtv/index.tsx
+++ b/pages/brendovi/gtv/index.tsx
@@ -30,7 +30,7 @@ const index = () => {
         catalogueValues={gtvKatalogVrednosti}
       />
       <TextoviISlike
-        title={"GTV"}
+        title={"GTV Logo"}
         naslovPasusa1={translate("naslov pasusa 1 gtv")}
         naslovPasusa2={translate("naslov pasusa 2 gtv")}
         naslovPasusa3={translate("naslov pasusa 3 gtv")}

--- a/pages/brendovi/hogert/index.tsx
+++ b/pages/brendovi/hogert/index.tsx
@@ -41,7 +41,7 @@ const index = () => {
         catalogueValues={hogertKatalogVrednosti}
       />
       <TextoviISlike
-      title={"Hogert"}
+      title={"Hogert Logo"}
       naslovPasusa1={translate("naslov pasusa 1 hogert")}
       naslovPasusa2={translate("naslov pasusa 2 hogert")}
       naslovPasusa3={translate("naslov pasusa 3 hogert")}

--- a/pages/brendovi/karcher/index.tsx
+++ b/pages/brendovi/karcher/index.tsx
@@ -36,7 +36,7 @@ const index = () => {
         catalogueValues={karcherKatalogVrednosti}
       />
       <TextoviISlike
-        title={"Karcher"}
+        title={"Karcher Logo"}
         naslovPasusa1={translate("naslov pasusa 1 karcher")}
         naslovPasusa2={translate("naslov pasusa 2 karcher")}
         naslovPasusa3={translate("naslov pasusa 3 karcher")}

--- a/pages/brendovi/knipex/index.tsx
+++ b/pages/brendovi/knipex/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={knipexKatalogVrednosti}
       />
       <TextoviISlike
-      title={"Knipex"}
+      title={"Knipex Logo"}
       naslovPasusa1={translate("naslov pasusa 1 knipex")}
       naslovPasusa2={translate("naslov pasusa 2 knipex")}
       naslovPasusa3={translate("naslov pasusa 3 knipex")}

--- a/pages/brendovi/kwb/index.tsx
+++ b/pages/brendovi/kwb/index.tsx
@@ -37,7 +37,7 @@ const index = () => {
         catalogueValues={kwbKatalogVrednosti}
       />
       <TextoviISlike
-      title={"KWB"}
+      title={"KWB Logo"}
       naslovPasusa1={translate("naslov pasusa 1 kwb")}
       naslovPasusa2={translate("naslov pasusa 2 kwb")}
       naslovPasusa3={translate("naslov pasusa 3 kwb")}

--- a/pages/brendovi/max/index.tsx
+++ b/pages/brendovi/max/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={maxKatalogVrednosti}
       />
       <TextoviISlike
-      title={"MAX"}
+      title={"MAX Logo"}
       naslovPasusa1={translate("naslov pasusa 1 max")}
       naslovPasusa2={translate("naslov pasusa 2 max")}
       naslovPasusa3={translate("naslov pasusa 3 max")}

--- a/pages/brendovi/mtx/index.tsx
+++ b/pages/brendovi/mtx/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={mtxKatalogVrednosti}
       />
       <TextoviISlike
-      title={"MTX"}
+      title={"MTX Logo"}
       naslovPasusa1={translate("naslov pasusa 1 mtx")}
       naslovPasusa2={translate("naslov pasusa 2 mtx")}
       naslovPasusa3={translate("naslov pasusa 3 mtx")}

--- a/pages/brendovi/rems/index.tsx
+++ b/pages/brendovi/rems/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={remsKatalogVrednosti}
       />
       <TextoviISlike
-      title={"REMS"}
+      title={"REMS Logo"}
       naslovPasusa1={translate("naslov pasusa 1 rems")}
       naslovPasusa2={translate("naslov pasusa 2 rems")}
       naslovPasusa3={translate("naslov pasusa 3 rems")}

--- a/pages/brendovi/rubi/index.tsx
+++ b/pages/brendovi/rubi/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={rubiKatalogVrednosti}
       />
       <TextoviISlike
-      title={"Rubi"}
+      title={"Rubi Logo"}
       naslovPasusa1={translate("naslov pasusa 1 rubi")}
       naslovPasusa2={translate("naslov pasusa 2 rubi")}
       naslovPasusa3={translate("naslov pasusa 3 rubi")}

--- a/pages/brendovi/senco/index.tsx
+++ b/pages/brendovi/senco/index.tsx
@@ -20,7 +20,7 @@ const index = () => {
         translate={translate}
       />
       <TextoviISlike
-       title={"Senco"}
+       title={"Senco Logo"}
        naslovPasusa1={translate("naslov pasusa 1 senco")}
        naslovPasusa2={translate("naslov pasusa 2 senco")}
        naslovPasusa3={translate("naslov pasusa 3 senco")}

--- a/pages/brendovi/sg-tools/index.tsx
+++ b/pages/brendovi/sg-tools/index.tsx
@@ -20,7 +20,7 @@ const index = () => {
         translate={translate}
       />
       <TextoviISlike
-       title={"SG Tools"}
+       title={"SG Tools Logo"}
        naslovPasusa1={translate("naslov pasusa 1 sg tools")}
        naslovPasusa2={translate("naslov pasusa 2 sg tools")}
        naslovPasusa3={translate("naslov pasusa 3 sg tools")}

--- a/pages/brendovi/sparta/index.tsx
+++ b/pages/brendovi/sparta/index.tsx
@@ -22,7 +22,7 @@ const index = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Hero
-        titleNaHomePage={"Sparta"}
+        titleNaHomePage={"Sparta Logo"}
         opisNaHomePage={translate("Sparta alati - Uvoznik za Srbiju")}
         naslovButtona={translate("Pogledaj PDF kataloge")}
         translate={translate}

--- a/pages/brendovi/stanley/index.tsx
+++ b/pages/brendovi/stanley/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={stanleyKatalogVrednosti}
       />
       <TextoviISlike
-      title={"Stanley"}
+      title={"Stanley Logo"}
       naslovPasusa1={translate("naslov pasusa 1 stanley")}
       naslovPasusa2={translate("naslov pasusa 2 stanley")}
       naslovPasusa3={translate("naslov pasusa 3 stanley")}

--- a/pages/brendovi/wera/index.tsx
+++ b/pages/brendovi/wera/index.tsx
@@ -22,7 +22,7 @@ const index = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Hero
-        titleNaHomePage={"Wera"}
+        titleNaHomePage={"Wera Logo"}
         opisNaHomePage={translate("Wera alati - Uvoznik za Srbiju")}
         naslovButtona={translate("Pogledaj PDF kataloge")}
         translate={translate}

--- a/pages/brendovi/wiha/index.tsx
+++ b/pages/brendovi/wiha/index.tsx
@@ -37,7 +37,7 @@ const index = () => {
         catalogueValues={wihaKatalogVrednosti}
       />
       <TextoviISlike
-      title={"Wiha"}
+      title={"Wiha Logo"}
       naslovPasusa1={translate("naslov pasusa 1 wiha")}
       naslovPasusa2={translate("naslov pasusa 2 wiha")}
       naslovPasusa3={translate("naslov pasusa 3 wiha")}

--- a/pages/brendovi/wolfcraft/index.tsx
+++ b/pages/brendovi/wolfcraft/index.tsx
@@ -29,7 +29,7 @@ const index = () => {
         catalogueValues={wolfcraftKatalogVrednosti}
       />
       <TextoviISlike
-        title={"Wolfcraft"}
+        title={"Wolfcraft Logo"}
         naslovPasusa1={translate("naslov pasusa 1 wolfcraft")}
         naslovPasusa2={translate("naslov pasusa 2 wolfcraft")}
         naslovPasusa3={translate("naslov pasusa 3 wolfcraft")}


### PR DESCRIPTION
There was only one image that didn't have an alt attribute (components/Hero.tsx). I noticed that <InstagramImg/>'s alt said <brand> Logo, but the other pages' alt only said <brand>. So the rest of the edits adds "Logo" to the other brand logo images' alt.

The only files I didn't add "Logo" to was /components/Card.tsx and /kataozi/Card.tsx because the parameter that sets the logo's alt attribute is also used as the page's header text. Let me know if you want me to concatenate "Logo" to the brands' alt attribute or if I should revert all the "Logo" edits back to how it was originally.

Resolves #11 