### PR TITLE
Each page only requests translations it needs

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -3,7 +3,8 @@ module.exports = {
     locales: ["sr", "en"],
     defaultLocale: "sr",
     localeDetection: false,
-    ns: ["common", "home"],
+    ns: ["common", "home", "kontakt", 
+      "NavBar", "Mapa", "Footer"],
   },
   interpolation: {
     escapeValue: false,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,14 +12,16 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import dynamic from "next/dynamic";
 function App({ Component, pageProps }: AppProps) {
   const { t: translate } = useTranslation("home");
+  const { t: translateNavBar } = useTranslation("NavBar");
+  const { t: translateFooter } = useTranslation("Footer");
   const { locale } = useRouter();
   const { statusCode } = pageProps;
   return (
     <main>
-      {statusCode != 404 && <Navbar locale={locale} translate={translate} />}
+      {statusCode != 404 && <Navbar locale={locale} translate={translateNavBar} />}
       <Component {...pageProps} />
       {/* <Analytics/> */}
-      {statusCode != 404 && <Footer translate={translate} />}
+      {statusCode != 404 && <Footer translate={translateFooter} />}
     </main>
   );
 }
@@ -28,7 +30,7 @@ export default appWithTranslation(App);
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -19,7 +19,7 @@ export default ErrorPage;
 export async function getStaticProps({locale}:any) {
   return{
     props:{
-      ...(await serverSideTranslations(locale,["home"]))
+      ...(await serverSideTranslations(locale,["home", "NavBar", "Footer"]))
     }
   }
 }

--- a/pages/b2b/index.tsx
+++ b/pages/b2b/index.tsx
@@ -33,7 +33,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/black-and-decker/index.tsx
+++ b/pages/brendovi/black-and-decker/index.tsx
@@ -40,7 +40,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/bosch/index.tsx
+++ b/pages/brendovi/bosch/index.tsx
@@ -74,7 +74,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/dewalt/index.tsx
+++ b/pages/brendovi/dewalt/index.tsx
@@ -55,7 +55,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/gtv/index.tsx
+++ b/pages/brendovi/gtv/index.tsx
@@ -52,7 +52,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/hogert/index.tsx
+++ b/pages/brendovi/hogert/index.tsx
@@ -61,7 +61,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/index.tsx
+++ b/pages/brendovi/index.tsx
@@ -36,7 +36,7 @@ export default index
 export async function getStaticProps({locale}:any) {
   return{
     props:{
-      ...(await serverSideTranslations(locale,['home']))
+      ...(await serverSideTranslations(locale,["home", "NavBar", "Footer"]))
     }
   }
 }

--- a/pages/brendovi/karcher/index.tsx
+++ b/pages/brendovi/karcher/index.tsx
@@ -56,7 +56,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/knipex/index.tsx
+++ b/pages/brendovi/knipex/index.tsx
@@ -51,7 +51,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/kwb/index.tsx
+++ b/pages/brendovi/kwb/index.tsx
@@ -57,7 +57,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/max/index.tsx
+++ b/pages/brendovi/max/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/mtx/index.tsx
+++ b/pages/brendovi/mtx/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/rems/index.tsx
+++ b/pages/brendovi/rems/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/rubi/index.tsx
+++ b/pages/brendovi/rubi/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/senco/index.tsx
+++ b/pages/brendovi/senco/index.tsx
@@ -40,7 +40,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/sg-tools/index.tsx
+++ b/pages/brendovi/sg-tools/index.tsx
@@ -40,7 +40,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/sparta/index.tsx
+++ b/pages/brendovi/sparta/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/stanley/index.tsx
+++ b/pages/brendovi/stanley/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/wera/index.tsx
+++ b/pages/brendovi/wera/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/wiha/index.tsx
+++ b/pages/brendovi/wiha/index.tsx
@@ -59,7 +59,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/brendovi/wolfcraft/index.tsx
+++ b/pages/brendovi/wolfcraft/index.tsx
@@ -49,7 +49,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,7 +47,7 @@ const {t:translate} = useTranslation('home')
 export async function getStaticProps({locale}:any) {
   return{
     props:{
-      ...(await serverSideTranslations(locale,['home']))
+      ...(await serverSideTranslations(locale,["home", "NavBar", "Footer"]))
     }
   }
 }

--- a/pages/katalozi/index.tsx
+++ b/pages/katalozi/index.tsx
@@ -31,7 +31,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/kontakt.tsx
+++ b/pages/kontakt.tsx
@@ -6,7 +6,8 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Hero from "@/components/Hero";
 
 const kontakt = () => {
-  const { t: translate } = useTranslation("home");
+  const { t: translate } = useTranslation("kontakt");
+  const { t: translateMapa } = useTranslation("Mapa");
   return (
     <div>
       <Head>
@@ -29,14 +30,14 @@ const kontakt = () => {
         translate={translate}
       />
       <Mapa
-        translate={translate}
+        translate={translateMapa}
         email={"office@stridon.rs"}
         kontakt={"011/2886-509"}
         adresa={"Vojislava Ilića 141g"}
         map_src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d90567.5103257972!2d20.365943012636272!3d44.81678309583739!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x475a7163a682044d%3A0x2a07a073e49f36ae!2sStridon%20group!5e0!3m2!1sen!2snl!4v1682522248790!5m2!1sen!2snl"
       />
       <Mapa
-        translate={translate}
+        translate={translateMapa}
         email={"office@stridon.rs"}
         kontakt={"011/210-0230"}
         adresa={"Altina - Ugrinovačka 212"}
@@ -51,7 +52,7 @@ export default kontakt;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["kontakt", "NavBar", "Mapa", "Footer"])),
     },
   };
 }

--- a/pages/onama/index.tsx
+++ b/pages/onama/index.tsx
@@ -118,7 +118,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/podacizaidentifikaciju/index.tsx
+++ b/pages/podacizaidentifikaciju/index.tsx
@@ -43,7 +43,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/politikaprivatnosti/index.tsx
+++ b/pages/politikaprivatnosti/index.tsx
@@ -23,7 +23,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", "NavBar", "Footer"])),
     },
   };
 }

--- a/pages/servis/index.tsx
+++ b/pages/servis/index.tsx
@@ -46,7 +46,7 @@ export default index;
 export async function getStaticProps({ locale }: any) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["home"])),
+      ...(await serverSideTranslations(locale, ["home", 'NavBar', 'Footer'])),
     },
   };
 }

--- a/public/locales/en/Footer.json
+++ b/public/locales/en/Footer.json
@@ -1,0 +1,9 @@
+{
+  "© 2025 Sva prava zaštićena. Stridon Group d.o.o.": "© 2025 All rights reserved. Stridon Group d.o.o.",
+  "Podaci za Identifikaciju · ": "Identification Data · ",
+  "Politika Privatnosti": "Privacy Policy",
+  "Call centar": "Call center",
+  "Radno Vreme": "Working hours",
+  "Informacije": "Informations",
+  "Kompanija": "Company"
+}

--- a/public/locales/en/Mapa.json
+++ b/public/locales/en/Mapa.json
@@ -1,0 +1,4 @@
+{
+  "Kontakt Telefon": "Contact Telephone",
+  "Adresa": "Address"
+}

--- a/public/locales/en/NavBar.json
+++ b/public/locales/en/NavBar.json
@@ -1,0 +1,14 @@
+{
+  "BrendoviHeader": "Brands",
+  "KataloziHeader": "Catalogs",
+  "ServisHeader": "Service",
+  "KontaktHeader": "Contact",
+  "BrendoviFon": "Brands",
+  "svi brendovi": "All brands",
+  "KataloziFon": "Catalogs",
+  "ServisFon": "Service",
+  "KontaktFon": "Contact",
+  "O namaFon": "About us",
+  "TranslateEn": "Translate to English",
+  "TranslateSr": "Translate into Serbian"
+}

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -37,6 +37,7 @@
   "BrandsHeroTitle": "Importer and distributor of the best brands",
   "BrandsHeroDescription": "Brands of machinery, accessories, electric, hand, and cordless tools that we import and for which our company is the importer and distributor in Serbia",
   
+  "KataloziHeader": "Catalogs",
   "opisNaKatalozima": "Explore our promotional catalogs to review a wide range of products and discover the best offers on machinery, power tools, and hand tools for both professional and domestic use.",
   
   "Bosch DIY merni alati": "Bosch DIY measuring tools",

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -33,18 +33,9 @@
   "Ko su naši klijenti?": "Who are our clients?",
   "klijenti": "Well-known renowned domestic companies in the fields of construction, carpentry, ceramics and others. Small and medium enterprises as well as individuals who need a quality tool and fast service!",
   
-  "BrendoviHeader": "Brands",
-  "KataloziHeader": "Catalogs",
-  "ServisHeader": "Service",
-  "KontaktHeader": "Contact",
   
   "BrandsHeroTitle": "Importer and distributor of the best brands",
   "BrandsHeroDescription": "Brands of machinery, accessories, electric, hand, and cordless tools that we import and for which our company is the importer and distributor in Serbia",
-  "BrendoviFon": "Brands",
-  "KataloziFon": "Catalogs",
-  "ServisFon": "Service",
-  "KontaktFon": "Contact",
-  "O namaFon": "About us",
   
   "opisNaKatalozima": "Explore our promotional catalogs to review a wide range of products and discover the best offers on machinery, power tools, and hand tools for both professional and domestic use.",
   
@@ -88,14 +79,6 @@
   "opisNaServisu": "We service and maintain electric, cordless, and hand tools - for professional and hobby use.",
   "Brendovi koje servisiramo": "Brands that we service",
   "ServiceTextBelowBrandsThatWeService": "We service tools and equipment from leading brands such as DeWalt, Bosch, Makita, Metabo, Festool, Rubi, and SENCO.",
-  "Kontakt Telefon": "Contact Telephone",
-  "Adresa": "Address",
-  
-  "Kontaktirajte nas!": "Contact us!",
-  "ContactTextBelowTitle": "Contact the Stridon team for questions, support, or collaboration. Our expert team is here to help you and provide information about our products and services.",
-  
-  "TranslateEn": "Translate to English",
-  "TranslateSr": "Translate into Serbian",
   
   "DeWalt": "DeWalt tools are among the highest quality tools of today. They are used in all industries, and there is no heavy task for DeWalt professional machines. D...",
   "Bosch": "Bosch is one of the world's largest companies that deals with the production of electric and hand tools. Bosch Professional represents a synonym for quality...",
@@ -362,11 +345,6 @@
   "KWBMetaTitle": "KWB tools store - Serbia, Belgrade | Stridon Group",
   "KWBMetaDescription": "Learn all about KWB tools, from history and innovations to product range and curiosities. Find accurate information about the products you're interested in.✅",
 
-  "Call centar": "Call center",
-  "Radno Vreme": "Working hours",
-  "Informacije": "Informations",
-  "Kompanija": "Company",
-
   "1": "Discover the latest price list of Bosch DIY measuring tools for June 2023. This comprehensive catalog provides the most current information on available measuring tools for DIY enthusiasts and hobbyists.",
   "2": "Explore the latest offers in our catalog of Bosch accessories for July 2023. Browse a wide selection of premium Bosch accessories that will enhance your tools and simplify your projects.",
   "3": "Explore the latest price list of Dremel tools and accessories for June 2023. In our catalog, you can find a rich assortment of high-quality Dremel tools and accessories to meet all your creative needs.",
@@ -478,8 +456,6 @@
   "Brendovi": "Brands",
   "Katalozi": "Catalogs",
   "Servis": "Service",
-  "© 2025 Sva prava zaštićena. Stridon Group d.o.o.": "© 2025 All rights reserved. Stridon Group d.o.o.",
-  "Podaci za Identifikaciju · ": "Identification Data · ",
   "Politika Privatnosti": "Privacy Policy",
 
   "AboutUsDescription": "Your trusted partner for quality tools and equipment in Serbia, serving professionals and DIY enthusiasts since 2009",

--- a/public/locales/en/kontakt.json
+++ b/public/locales/en/kontakt.json
@@ -1,0 +1,4 @@
+{
+  "Kontaktirajte nas!": "Contact us!",
+  "ContactTextBelowTitle": "Contact the Stridon team for questions, support, or collaboration. Our expert team is here to help you and provide information about our products and services."
+}

--- a/public/locales/sr/Footer.json
+++ b/public/locales/sr/Footer.json
@@ -1,0 +1,9 @@
+{
+  "© 2025 Sva prava zaštićena. Stridon Group d.o.o.": "© 2025 Sva prava zaštićena. Stridon Group d.o.o.",
+  "Podaci za Identifikaciju · ": "Podaci za Identifikaciju · ",
+  "Politika Privatnosti": "Politika Privatnosti",
+  "Call centar": "Call centar",
+  "Radno Vreme": "Radno vreme",
+  "Informacije": "Informacije",
+  "Kompanija": "Kompanija"
+}

--- a/public/locales/sr/Mapa.json
+++ b/public/locales/sr/Mapa.json
@@ -1,0 +1,4 @@
+{
+  "Kontakt Telefon": "Kontakt Telefon",
+  "Adresa": "Adresa"
+}

--- a/public/locales/sr/NavBar.json
+++ b/public/locales/sr/NavBar.json
@@ -1,0 +1,14 @@
+{
+  "BrendoviHeader": "Brendovi",
+  "KataloziHeader": "Katalozi",
+  "ServisHeader": "Servis",
+  "KontaktHeader": "Kontakt",
+  "BrendoviFon": "Brendovi",
+  "svi brendovi": "Svi brendovi",
+  "KataloziFon": "Katalozi",
+  "ServisFon": "Servis",
+  "KontaktFon": "Kontakt",
+  "O namaFon": "O nama",
+  "TranslateEn": "Prevedi na engleski",
+  "TranslateSr": "Prevedi na srpski"
+}

--- a/public/locales/sr/home.json
+++ b/public/locales/sr/home.json
@@ -36,6 +36,7 @@
   "BrandsHeroTitle": "Uvoznik i distributer najboljih brendova",
   "BrandsHeroDescription": "Brendovi mašina, pribora, električnog, ručnog i akumulatorskog alata koje uvozimo i za koje je naša firma uvoznik i distributer na teritoriji Srbije.",
 
+  "KataloziHeader": "Katalozi",
   "opisNaKatalozima": "Pregledajte širok izbor proizvoda i najbolje ponude mašina, električnog i ručnog alata za profesionalnu i kućnu upotrebu u našim akcijskim katalozima.",
 
   "Bosch DIY merni alati": "Bosch DIY merni alati",

--- a/public/locales/sr/home.json
+++ b/public/locales/sr/home.json
@@ -35,16 +35,6 @@
 
   "BrandsHeroTitle": "Uvoznik i distributer najboljih brendova",
   "BrandsHeroDescription": "Brendovi mašina, pribora, električnog, ručnog i akumulatorskog alata koje uvozimo i za koje je naša firma uvoznik i distributer na teritoriji Srbije.",
-  "BrendoviHeader": "Brendovi",
-  "KataloziHeader": "Katalozi",
-  "ServisHeader": "Servis",
-  "KontaktHeader": "Kontakt",
-
-  "BrendoviFon": "Brendovi",
-  "KataloziFon": "Katalozi",
-  "ServisFon": "Servis",
-  "KontaktFon": "Kontakt",
-  "O namaFon": "O nama",
 
   "opisNaKatalozima": "Pregledajte širok izbor proizvoda i najbolje ponude mašina, električnog i ručnog alata za profesionalnu i kućnu upotrebu u našim akcijskim katalozima.",
 
@@ -88,14 +78,6 @@
   "opisNaServisu": "Servisiramo i održavamo električne, akumulatorske i ručne alate - za profesionalnu i hobi upotrebu.",
   "Brendovi koje servisiramo": "Brendovi koje servisiramo",
   "ServiceTextBelowBrandsThatWeService": "Servisiramo alate i opremu vodećih brendova kao što su DeWalt, Bosch, Makita, Metabo, Festool, Rubi i SENCO.",
-  "Kontakt Telefon": "Kontakt Telefon",
-  "Adresa": "Adresa",
-
-  "Kontaktirajte nas!": "Kontaktirajte nas!",
-  "ContactTextBelowTitle": "Kontaktirajte Stridon tim za pitanja, podršku ili saradnju. Naša stručna ekipa je tu da vam pomogne i pruži informacije o našim proizvodima i uslugama.",
-
-  "TranslateEn": "Prevedi na engleski",
-  "TranslateSr": "Prevedi na srpski",
 
   "DeWalt": "DeWalt alati su jedni od najkvalitetnijih alata današnjice. Koriste se u svim industrijama i nema preteškog posla za DeWalt profesionalne mašine. D...",
   "Bosch": "Bosch je jedna od najvećih svetskih firmi koja se bavi proizvodnjom električnih i ručnih alata. Bosch Professional predstavlja sinonim za kvalitet ...",
@@ -362,11 +344,6 @@
   "KWBMetaTitle": "KWB alati prodavnica - Srbija, Beograd | Stridon Group",
   "KWBMetaDescription": "Saznajte sve o KWB alatu, od bogate istorije i inovacija do asortimana proizvoda i zanimljivosti. Pronađite prave informacije o proizvodima koji Vas zanimaju.✅",
 
-  "Call centar": "Call centar",
-  "Radno Vreme": "Radno vreme",
-  "Informacije": "Informacije",
-  "Kompanija": "Kompanija",
-
   "1": "Upoznajte se sa najnovijim cenovnikom Bosch DIY mernih alata za jun 2023. Ovaj sveobuhvatni cenovnik donosi najaktuelnije informacije o raspoloživim mernim alatima za kućne majstore i entuzijaste.",
   "2": "Otkrijte najnovije ponude u našem cenovniku Bosch pribora za mesec jul 2023. Pregledajte bogat izbor vrhunskog Bosch pribora koji će unaprediti vaše alate i olakšati vaše projekte.",
   "3": "Istražite najnoviji cenovnik Dremel alata i pribora za jun 2023. U našem cenovniku možete pronaći bogat izbor visokokvalitetnih Dremel alata i pribora koji će ispuniti sve vaše kreativne potrebe.",
@@ -478,8 +455,6 @@
   "Brendovi": "Brendovi",
   "Katalozi": "Katalozi",
   "Servis": "Servis",
-  "© 2025 Sva prava zaštićena. Stridon Group d.o.o.": "© 2025 Sva prava zaštićena. Stridon Group d.o.o.",
-  "Podaci za Identifikaciju · ": "Podaci za Identifikaciju · ",
   "Politika Privatnosti": "Politika Privatnosti",
 
   "AboutUsDescription": "Pouzdan partner za kvalitetan alat i opremu u Srbiji, uz vas od 2009. godine",

--- a/public/locales/sr/kontakt.json
+++ b/public/locales/sr/kontakt.json
@@ -1,0 +1,4 @@
+{
+  "Kontaktirajte nas!": "Kontaktirajte nas!",
+  "ContactTextBelowTitle": "Kontaktirajte Stridon tim za pitanja, podršku ili saradnju. Naša stručna ekipa je tu da vam pomogne i pruži informacije o našim proizvodima i uslugama."
+}


### PR DESCRIPTION
The current plan is to create JSON files that have the exact same name as the page/component that uses that file. I did this for the 'Contact' page as an example. I also did this for the NavBar, Mapa, and Footer components because the 'Contact' page uses them. 
If you think this method is good, then let me know and I will finish the rest of the translations like this. Or lmk if you had a different way you think this should get done.

Resolves #9